### PR TITLE
feat: add support for custom Ngrok domains and filter placeholder credentials

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,9 @@ TUNNEL_PROVIDER=ngrok
 # This prevents the 1-hour session limit and allows stable connections
 NGROK_AUTHTOKEN=your-ngrok-authtoken
 
+# Your custom ngrok domain (Optional - for persistent domains/subdomains)
+# NGROK_DOMAIN=yourname.ngrok-free.app
+
 # Pinggy Access Token (Optional - for persistent subdomain)
 # Get a free token from https://dashboard.pinggy.io
 # PINGGY_TOKEN=your-pinggy-token

--- a/launcher.py
+++ b/launcher.py
@@ -114,6 +114,15 @@ def main():
     # Load .env if it exists
     load_dotenv()
 
+    # Clean up placeholder ngrok environment variables
+    token = os.environ.get('NGROK_AUTHTOKEN')
+    if token in ('your-ngrok-authtoken', 'your_actual_ngrok_authtoken_here'):
+        del os.environ['NGROK_AUTHTOKEN']
+
+    domain = os.environ.get('NGROK_DOMAIN')
+    if domain == 'yourname.ngrok-free.app':
+        del os.environ['NGROK_DOMAIN']
+
     # Determine Provider
     provider = args.provider or os.environ.get('TUNNEL_PROVIDER', 'ngrok').lower()
     
@@ -298,10 +307,14 @@ def main():
                 if token:
                     ngrok.set_auth_token(token)
                 else:
-                    print("⚠️  Warning: NGROK_AUTHTOKEN not found in .env. Tunnel might expire.")
+                    print("⚠️  Warning: NGROK_AUTHTOKEN not found or is default placeholder in .env. Tunnel might expire in 1 hour.")
 
+                ngrok_domain = os.environ.get('NGROK_DOMAIN')
                 print("PLEASE WAIT... Establishing Ngrok Tunnel...")
-                tunnel = ngrok.connect(addr, host_header="rewrite")
+                if ngrok_domain:
+                    tunnel = ngrok.connect(addr, host_header="rewrite", domain=ngrok_domain)
+                else:
+                    tunnel = ngrok.connect(addr, host_header="rewrite")
                 public_url = tunnel.public_url
             
             # Magic URL with password


### PR DESCRIPTION
This pull request introduces two improvements for users accessing the tunnel via Ngrok:

1. **Custom Domain Support**: Adds support for custom, persistent Ngrok domains by reading the `NGROK_DOMAIN` environment variable from `.env`.
2. **Placeholder Filtering**: Prevents connection crashes when default placeholder values (e.g. `your-ngrok-authtoken` or `yourname.ngrok-free.app`) are left untouched in the local `.env` file. It warns the user but successfully starts the connection on an ephemeral tunnel.

These changes make Ngrok setups much more robust and configurable.